### PR TITLE
This patch was done with the intention of allowing for more than one …

### DIFF
--- a/staticValues.example.js
+++ b/staticValues.example.js
@@ -1,125 +1,136 @@
 module.exports = {
 
-    "botToken" : '',
-    
-    "symbols" : {
-        'Success': '<:success:xxxxxxxxxxxxxxxxxx>',
-        'Advantage': '<:advantage:xxxxxxxxxxxxxxxxxx>',
-        'Failure': '<:failure:xxxxxxxxxxxxxxxxxx>',
-        'Threat': '<:threat:xxxxxxxxxxxxxxxxxx>',
-        'Triumph': '<:triumph:xxxxxxxxxxxxxxxxxx>',
-        'Despair': '<:despair:xxxxxxxxxxxxxxxxxx>',
-        'Black': '<:darkside:xxxxxxxxxxxxxxxxxx>',
-        'White': '<:lightside:xxxxxxxxxxxxxxxxxx>',
-        'd20': '',
-    },
+  "botToken" : '',
 
-    "diceArray" : {
-      'g': {
-          'sides':8,
-          'emoji':'<:abilitybg:xxxxxxxxxxxxxxxxxx>',
-          'faces':{
-            1: 'Blank',
-            2: 'Success',
-            3: 'Success',
-            4: 'Success Success', 
-            5: 'Advantage',
-            6: 'Advantage',
-            7: 'Advantage Success',
-            8: 'Advantage Advantage'
-            }
-        },
-      'y': {
-          'sides':12,
-          'emoji':'<:proficiencybg:xxxxxxxxxxxxxxxxxx>',
-          'faces':{
-            1: 'Blank',
-            2: 'Success',
-            3: 'Success Success',
-            4: 'Success Success',
-            5: 'Advantage',
-            6: 'Advantage Success',
-            7: 'Advantage Success',
-            8: 'Advantage Success',
-            9: 'Advantage Advantage',
-            10: 'Advantage Advantage',
-            11: 'Advantage Advantage',
-            12: 'Triumph'
-            }
-        },
-      'b': {
-          'sides':6,
-          'emoji':'<:boostbg:xxxxxxxxxxxxxxxxxx>',
-          'faces':{
-            1: 'Blank',
-            2: 'Blank',
-            3: 'Success',
-            4: 'Advantage Success',
-            5: 'Advantage',
-            6: 'Advantage Advantage'
-            }
-        },
-      'p': {
-          'sides':8,
-          'emoji':'<:difficultybg:xxxxxxxxxxxxxxxxxx>',
-          'faces':{
-            1: 'Blank',
-            2: 'Failure',
-            3: 'Failure Failure',
-            4: 'Threat', 
-            5: 'Threat',
-            6: 'Threat',
-            7: 'Threat Threat',
-            8: 'Threat Failure'
-            }
-        },
-      'r': {
-          'sides':12,
-          'emoji':'<:challengebg:xxxxxxxxxxxxxxxxxx>',
-          'faces':{
-            1: 'Blank',
-            2: 'Failure',
-            3: 'Failure',
-            4: 'Failure Failure',
-            5: 'Failure Failure',
-            6: 'Threat',
-            7: 'Threat',
-            8: 'Threat Failure',
-            9: 'Threat Failure',
-            10: 'Threat Threat',
-            11: 'Threat Threat',
-            12: 'Despair'
-            }
-        },
-      'k': {
-          'sides':6,
-          'emoji':'<:setbackbg:xxxxxxxxxxxxxxxxxx>',
-          'faces':{
-            1: 'Blank',
-            2: 'Blank',
-            3: 'Failure',
-            4: 'Failure',
-            5: 'Threat',
-            6: 'Threat'
-            }
-        },
-      'f': {
-          'sides':12,
-          'emoji':'<:forcebg:xxxxxxxxxxxxxxxxxx>',
-          'faces':{
-            1: 'Black',
-            2: 'Black',
-            3: 'Black',
-            4: 'Black',
-            5: 'Black',
-            6: 'Black',
-            7: 'Black Black',
-            8: 'White',
-            9: 'White',
-            10: 'White White',
-            11: 'White White',
-            12: 'White White'
-            }
-        }
+  "symbols" : {
+    //Keys are Guild (Server) ID
+    //Use 'Get Server ID' in chat to get current Guild (Server) ID
+    'xxxxxxxxxxxxxxxxxx':{
+      //Server Name:
+      'Success':    '<:success:xxxxxxxxxxxxxxxxxx>',
+      'Advantage':  '<:advantage:xxxxxxxxxxxxxxxxxx>',
+      'Failure':    '<:failure:xxxxxxxxxxxxxxxxxx>',
+      'Threat':     '<:threat:xxxxxxxxxxxxxxxxxx>',
+      'Triumph':    '<:triumph:xxxxxxxxxxxxxxxxxx>',
+      'Despair':    '<:despair:xxxxxxxxxxxxxxxxxx>',
+      'Black':      '<:darkside:xxxxxxxxxxxxxxxxxx>',
+      'White':      '<:lightside:xxxxxxxxxxxxxxxxxx>',
+      'd20':        '<:d20:xxxxxxxxxxxxxxxxxx>',
+      'Blank':      '',
+      'g':          '<:abilitybg:xxxxxxxxxxxxxxxxxx>',
+      'y':          '<:proficiencybg:xxxxxxxxxxxxxxxxxx>',
+      'b':          '<:boostbg:xxxxxxxxxxxxxxxxxx>',
+      'p':          '<:difficultybg:xxxxxxxxxxxxxxxxxx>',
+      'r':          '<:challengebg:xxxxxxxxxxxxxxxxxx>',
+      'k':          '<:setbackbg:xxxxxxxxxxxxxxxxxx>',
+      'f':          '<:forcebg:xxxxxxxxxxxxxxxxxx>'
+    },
+    //You can add a second server 
+    //'xxxxxxxxxxxxxxxxxx':{
+    //  'Success':    '<:success:xxxxxxxxxxxxxxxxxx>',
+    //  etc
+    //}
+  },
+
+  "diceArray" : {
+  'g': {
+    'sides':8,
+    'faces':{
+      1: 'Blank',
+      2: 'Success',
+      3: 'Success',
+      4: 'Success Success', 
+      5: 'Advantage',
+      6: 'Advantage',
+      7: 'Advantage Success',
+      8: 'Advantage Advantage'
+      }
+    },
+  'y': {
+    'sides':12,
+    'faces':{
+      1: 'Blank',
+      2: 'Success',
+      3: 'Success Success',
+      4: 'Success Success',
+      5: 'Advantage',
+      6: 'Advantage Success',
+      7: 'Advantage Success',
+      8: 'Advantage Success',
+      9: 'Advantage Advantage',
+      10: 'Advantage Advantage',
+      11: 'Advantage Advantage',
+      12: 'Triumph'
+      }
+    },
+  'b': {
+    'sides':6,
+    'faces':{
+      1: 'Blank',
+      2: 'Blank',
+      3: 'Success',
+      4: 'Advantage Success',
+      5: 'Advantage',
+      6: 'Advantage Advantage'
+      }
+    },
+  'p': {
+    'sides':8,
+    'faces':{
+      1: 'Blank',
+      2: 'Failure',
+      3: 'Failure Failure',
+      4: 'Threat', 
+      5: 'Threat',
+      6: 'Threat',
+      7: 'Threat Threat',
+      8: 'Threat Failure'
+      }
+    },
+  'r': {
+    'sides':12,
+    'faces':{
+      1: 'Blank',
+      2: 'Failure',
+      3: 'Failure',
+      4: 'Failure Failure',
+      5: 'Failure Failure',
+      6: 'Threat',
+      7: 'Threat',
+      8: 'Threat Failure',
+      9: 'Threat Failure',
+      10: 'Threat Threat',
+      11: 'Threat Threat',
+      12: 'Despair'
+      }
+    },
+  'k': {
+    'sides':6,
+    'faces':{
+      1: 'Blank',
+      2: 'Blank',
+      3: 'Failure',
+      4: 'Failure',
+      5: 'Threat',
+      6: 'Threat'
+      }
+    },
+  'f': {
+    'sides':12,
+    'faces':{
+      1: 'Black',
+      2: 'Black',
+      3: 'Black',
+      4: 'Black',
+      5: 'Black',
+      6: 'Black',
+      7: 'Black Black',
+      8: 'White',
+      9: 'White',
+      10: 'White White',
+      11: 'White White',
+      12: 'White White'
+      }
     }
+  }
 }

--- a/sw-dice.js
+++ b/sw-dice.js
@@ -13,6 +13,10 @@ client.on("message", msg => {
   let starWarsDieConstraints = new RegExp(/(\d+[ygbprkf])/g);
   let regularDieConstraints = new RegExp(/(\d+[d]\d*[+]?\d*)/g);
 
+  if (msg.content.startsWith('Get Server ID')){
+    msg.channel.sendMessage(msg.guild.id);
+  }
+
   if (!msg.content.startsWith(prefix) || msg.author.bot) return;
 
   if (msg.content.search(starWarsRollConstraints) == -1 && msg.content.search(regularRollConstraints) == -1){
@@ -52,7 +56,7 @@ client.on("message", msg => {
     var finalValue = 0;
 
     for(var die in rolledDicePool){
-      printString += staticValues.symbols['d20'] + rolledDicePool[die] + '   ';;
+      printString += staticValues.symbols[msg.guild.id]['d20'] + rolledDicePool[die] + '   ';;
       finalValue += parseInt(rolledDicePool[die]);
     };
 
@@ -87,11 +91,11 @@ client.on("message", msg => {
         for(var y=0;y<numDice;y++){
           var numberRolledOnDie = Math.floor((Math.random() * numSides) + 1);
           var dieValue = staticValues.diceArray[thisDieType].faces[numberRolledOnDie];
-          var thisDieText = staticValues.diceArray[thisDieType].emoji;
+          var thisDieText = staticValues.symbols[msg.guild.id][thisDieType];
           var splitDieValue = dieValue.split(' ');
           for(var xx=0;xx<splitDieValue.length;xx++){
             symbolPool.push(splitDieValue[xx]);
-            thisDieText += staticValues.symbols[splitDieValue[xx]];
+            thisDieText += staticValues.symbols[msg.guild.id][splitDieValue[xx]];
           }
           rolledDiePool.push(thisDieText);
         }
@@ -111,7 +115,7 @@ client.on("message", msg => {
       for(var key in settledSymbols){
         if(settledSymbols[key] != 0){
           for(var yy=0;yy<settledSymbols[key];yy++){
-            printString += staticValues.symbols[key];
+            printString += staticValues.symbols[msg.guild.id][key];
           }
         }
       }


### PR DESCRIPTION
…server to use the same bot. Perviously, because each server had its own emoji, the ID's for said emoji were different per server. That meant that when using the bot in seperate servers, it would print nonsence in the server that it wasn't set up with.

This patch uses the ID for the Server as a key for the emoji object. Now to add the bot to a second server, all you have to do it add the bot as a user, duplicate the object in staticValues.js, and fill it in with the second server's emoji IDs.

The purpose of this was to use the same bot in both my personal server, as well as a generic one for the public to use. Eventually, I'd love to add a DB component that allows for a single bot instance to be used in any server. This would require some kind of input from a user, to set the emoji tokens for their given server.